### PR TITLE
fix: Wrong name in prisonbreak.lua

### DIFF
--- a/client/prisonbreak.lua
+++ b/client/prisonbreak.lua
@@ -144,7 +144,7 @@ CreateThread(function()
         currentGate = 0
         local sleep = 1000
         if LocalPlayer.state.isLoggedIn then
-            if QBX.PlayerData.PlayerJob.type ~= "leo" then
+            if QBX.PlayerData.job.type ~= "leo" then
                 local pos = GetEntityCoords(cache.ped)
                 for k in pairs(gates) do
                     local dist =  #(pos - gates[k].coords)


### PR DESCRIPTION
## Description

Error is thrown because PlayerJob does not exist.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
