### PR TITLE
refactor!: server exports and deprecation client events

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -201,7 +201,7 @@ local function onEnter(minutes)
 end
 
 RegisterNetEvent('qbx_prison:client:playerJailed', function(minutes)
-	if source == '' then return end
+	if GetInvokingResource() then return end
 	onEnter(minutes)
 end)
 
@@ -226,7 +226,7 @@ local function release()
 end
 
 RegisterNetEvent('qbx_prison:client:playerReleased', function()
-	if source == '' then return end
+	if GetInvokingResource() then return end
 	release()
 end)
 

--- a/client/prisonbreak.lua
+++ b/client/prisonbreak.lua
@@ -189,11 +189,9 @@ CreateThread(function()
             RemoveBlip(CellsBlip)
             RemoveBlip(TimeBlip)
             RemoveBlip(ShopBlip)
-            TriggerServerEvent("prison:server:SecurityLockdown")
             TriggerEvent("prison:client:PrisonBreakAlert")
-            TriggerServerEvent("prison:server:SetJailStatus", 0)
-            TriggerServerEvent("prison:server:GiveJailItems", true)
             exports.qbx_core:Notify(Lang:t("error.escaped"), "error")
+            TriggerServerEvent('qbx_prison:server:playerEscaped')
         end
         Wait(1000)
     end


### PR DESCRIPTION
Shifting client side event triggers to jail/release players to server side exports. Part of a larger effort to shift more code to the server side as currently the resource is very client driven.
