### PR TITLE
refactor: convert to ox_target

### DIFF
--- a/client/jobs.lua
+++ b/client/jobs.lua
@@ -100,13 +100,9 @@ CreateThread(function()
         for i = 1, #Config.Locations.jobs[k] do
             local current = Config.Locations.jobs[k][i]
             if Config.UseTarget then
-                exports['qb-target']:AddBoxZone("work_"..k.."_"..i, current.coords.xyz, 1.5, 1.6, {
-                    name = "work_"..k.."_"..i,
-                    heading = 12.0,
-                    debugPoly = false,
-                    minZ = 19,
-                    maxZ = 219
-                }, {
+                exports.ox_target:addBoxZone({
+                    coords = current.coords.xyz,
+                    size = vec3(1.5, 1.6, 5),
                     options = {
                         {
                             icon = 'fa-solid fa-bolt',
@@ -114,12 +110,9 @@ CreateThread(function()
                             canInteract = function()
                                 return InJail and CurrentJob and not Config.Locations.jobs[k][i].done and not isWorking and i == currentLocation
                             end,
-                            action = function()
-                                startWork()
-                            end
+                            onSelect = startWork
                         }
-                    },
-                    distance = 2.5
+                    }
                 })
             else
                 local electricityzone = BoxZone:Create(current.coords.xyz, 3.0, 5.0, {

--- a/client/prisonbreak.lua
+++ b/client/prisonbreak.lua
@@ -78,7 +78,7 @@ RegisterNetEvent('prison:client:SetLockDown', function(isLockdown)
 end)
 
 RegisterNetEvent('prison:client:PrisonBreakAlert', function()
-    local coords = Config.Locations.middle.coords.xyz
+    local coords = Config.Locations.middle.coords
     local alertData = {title = Lang:t("info.police_alert_title"), coords = {x = coords.x, y = coords.y, z = coords.z}, description = Lang:t("info.police_alert_description")}
     TriggerEvent("qb-phone:client:addPoliceAlert", alertData)
     TriggerEvent('police:client:policeAlert', coords, Lang:t("info.police_alert_description"))
@@ -177,22 +177,21 @@ CreateThread(function()
     end
 end)
 
---- TODO: switch to using a zone
---- check for an escape
-CreateThread(function()
-    while true do
-        local pos = GetEntityCoords(cache.ped, true)
-        if #(pos.xy - Config.Locations.middle.coords.xy) > 200 and InJail then
-            InJail = false
-            JailTime = 0
-            RemoveBlip(CurrentBlip)
-            RemoveBlip(CellsBlip)
-            RemoveBlip(TimeBlip)
-            RemoveBlip(ShopBlip)
-            TriggerEvent("prison:client:PrisonBreakAlert")
-            exports.qbx_core:Notify(Lang:t("error.escaped"), "error")
-            TriggerServerEvent('qbx_prison:server:playerEscaped')
-        end
-        Wait(1000)
-    end
-end)
+local function checkForEscape()
+    if not InJail then return end
+    InJail = false
+    JailTime = 0
+    RemoveBlip(CurrentBlip)
+    RemoveBlip(CellsBlip)
+    RemoveBlip(TimeBlip)
+    RemoveBlip(ShopBlip)
+    TriggerEvent("prison:client:PrisonBreakAlert")
+    exports.qbx_core:Notify(Lang:t("error.escaped"), "error")
+    TriggerServerEvent('qbx_prison:server:playerEscaped')
+end
+
+lib.zones.sphere({
+    coords = Config.Locations.middle.coords,
+    radius = 200,
+    onExit = checkForEscape,
+})

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 
-Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
+Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use ox_target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
 Config.Jobs = {
     electrician = "Electrician"
@@ -63,7 +63,7 @@ Config.Locations = {
         coords = vector4(1765.67, 2565.91, 44.56, 1.5)
     },
     middle = {
-        coords = vector4(1693.33, 2569.51, 44.55, 123.5)
+        coords = vec3(1693.33, 2569.51, 44.55)
     },
     shop = {
         coords = vector4(1777.59, 2560.52, 44.62, 187.83)
@@ -120,17 +120,11 @@ Config.CanteenItems = {
     {
         name = "sandwich",
         price = 4,
-        amount = 50,
-        info = {},
-        type = "item",
-        slot = 1
+        count = 50,
     },
     {
         name = "water_bottle",
         price = 4,
-        amount = 50,
-        info = {},
-        type = "item",
-        slot = 2
+        count = 50,
     }
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -110,6 +110,11 @@ lib.callback.register('prison:server:IsAlarmActive', function()
     return alarmActivated
 end)
 
+exports.ox_inventory:RegisterShop('Canteen', {
+    name = 'Prison Canteen',
+    inventory = Config.CanteenItems,
+})
+
 ---@deprecated do not call this event
 RegisterNetEvent('prison:server:SaveJailItems', function()
     lib.print.error(GetInvokingResource(), "invoked deprecated prison:server:SaveJailedItems event. Event has no effect.")


### PR DESCRIPTION
- using ox_target instead of qb-target
- using an ox_lib zone for checking for a prison escape instead of using a loop + distance check
- registering the canteen as a shop and then opening it from the client
- converted some events to local functions and deprecated them.