### PR TITLE
release player server event

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -107,7 +107,7 @@ local function askToLeave()
 	if JailTime > 0 then
 		exports.qbx_core:Notify( Lang:t("info.timeleft", {JAILTIME = JailTime}))
 	else
-		release()
+		TriggerServerEvent("rs_prison:server:releasePlayer")
 	end
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -107,7 +107,7 @@ local function askToLeave()
 	if JailTime > 0 then
 		exports.qbx_core:Notify( Lang:t("info.timeleft", {JAILTIME = JailTime}))
 	else
-		TriggerServerEvent("rs_prison:server:releasePlayer")
+		TriggerServerEvent("qbx_prison:server:releasePlayer")
 	end
 end
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -28,7 +28,7 @@ local function jailPlayer(src, minutes)
     player.Functions.AddMoney('cash', 80)
 
     setJailStatus(src, minutes)
-    TriggerClientEvent('qbx_prison:client:playerJailed', src)
+    TriggerClientEvent('qbx_prison:client:playerJailed', src, minutes)
 end
 
 exports('JailPlayer', jailPlayer)

--- a/server/main.lua
+++ b/server/main.lua
@@ -42,7 +42,7 @@ end
 
 exports('ReleasePlayer', releasePlayer)
 
-RegisterNetEvent("rs_prison:server:releasePlayer", function ()
+RegisterNetEvent("qbx_prison:server:releasePlayer", function ()
     local src = source
     local Player = exports.qbx_core:GetPlayer(src)
     if not Player then return end

--- a/server/main.lua
+++ b/server/main.lua
@@ -42,6 +42,18 @@ end
 
 exports('ReleasePlayer', releasePlayer)
 
+RegisterNetEvent("rs_prison:server:releasePlayer", function ()
+    local src = source
+    local Player = exports.qbx_core:GetPlayer(src)
+    if not Player then return end
+    if Player.Functions.metadata.injail and Player.Functions.metadata.injail == 0 then
+        setJailStatus(src, 0)
+        exports.ox_inventory:ReturnInventory(src)
+        exports.qbx_core:Notify(src, Lang:t("info.received_property"))
+        TriggerClientEvent('qbx_prison:client:playerReleased', src) 
+    end
+end)
+
 local function securityLockdown()
     TriggerClientEvent("prison:client:SetLockDown", -1, true)
     for _, player in pairs(exports.qbx_core:GetQBPlayers()) do


### PR DESCRIPTION
created a route that goes through the server as the confiscated items event to return them was never triggered. 

the server triggers another client event which goes over the release() function. Player gets released and gets his items back. + another check for jail time 