### PR TITLE
refactor(client): use correct model name

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -160,14 +160,14 @@ local function openCanteen()
 end
 
 local function pedCreate(pedModel, position, scenario)
-    local model = lib.requestModel(pedModel)
-    local entity = CreatePed(0, model, position.x, position.y, position.z, position.w, false, true)
+    lib.requestModel(pedModel, 10000)
+    local entity = CreatePed(0, pedModel, position.x, position.y, position.z, position.w, false, true)
 
     if scenario then
         TaskStartScenarioInPlace(entity, scenario, 0, true)
     end
 
-    SetModelAsNoLongerNeeded(model)
+    SetModelAsNoLongerNeeded(pedModel)
     FreezeEntityPosition(entity, true)
     SetEntityInvincible(entity, true)
     SetBlockingOfNonTemporaryEvents(entity, true)


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
lib.requestModel returns true if loaded not the model name. This fixes that

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
